### PR TITLE
added dbSNP INFO field annotations to dbSNP datasource class

### DIFF
--- a/oncotator/datasources.py
+++ b/oncotator/datasources.py
@@ -838,7 +838,7 @@ class dbSNP(IndexedVCF_DataSource):
         self.title = title
     
         super(dbSNP, self).__init__(src_file, title=self.title, version=version)
-        self.output_headers = ['dbSNP_RS', 'dbSNP_Val_Status']
+        self.output_headers = ['dbSNP_RS', 'dbSNP_Val_Status', 'dbSNP_INFO']
         self.logger = logging.getLogger(__name__)
     
     def annotate_mutation(self, mutation):


### PR DESCRIPTION
An additional annotation that ensures no crucial annotations from the INFO field in a dbSNP vcf are lost.  The entire INFO field  as it is presented by the pyvcf parser is serialized to a json string.
