### PR TITLE
Issue 27 -- GAF Caching

### DIFF
--- a/oncotator/datasources.py
+++ b/oncotator/datasources.py
@@ -63,6 +63,7 @@ from oncotator.index.gaf import region2bins
 import vcf
 import logging
 import re
+from oncotator.utils.Hasher import Hasher
 from oncotator.utils.MutUtils import MutUtils
 from oncotator.utils.gaf_annotation import GAFNonCodingTranscript
 from oncotator.utils.dbNSFP import dbnsfp_fieldnames
@@ -108,6 +109,10 @@ class TranscriptProvider(object):
     @abc.abstractmethod
     def set_tx_mode(self, tx_mode):
         # TODO: Throw exception if not in TX_MODE_CHOICES
+        return
+
+    @abc.abstractmethod
+    def get_tx_mode(self):
         return
 
 
@@ -251,8 +256,21 @@ class Gaf(Datasource, TranscriptProvider):
         # TODO: Check for valid values.
         self.tx_mode = tx_mode
 
-    def set_tx_mode(self, tx_mode):
-        self.tx_mode = tx_mode
+    def get_tx_mode(self):
+        return self.tx_mode
+
+    def set_tx_mode(self, value):
+        self.tx_mode = value
+
+    def get_hashcode(self):
+        """The GAF datasource has to adjust  its key based on the internal tx mode.  set_hashcode sends in
+         an initial hashcode, which is then adjusted by tx-mode
+
+         """
+        hasher = Hasher()
+        hasher.update(self.hashcode)
+        hasher.update(self.get_tx_mode())
+        return hasher.hexdigest()
 
     def retrieveExons(self, gene, padding=10, isCodingOnly=False):
         """Return a list of (chr, start, end) tuples for each exon"""

--- a/test/GafDatasourceTest.py
+++ b/test/GafDatasourceTest.py
@@ -462,6 +462,16 @@ class GafDatasourceTest(unittest.TestCase):
             ctr += 1
         self.assertTrue(ctr == 730, "Should have read 730 variants, but read " + str(ctr))
 
+    def testChangeInTxModeChangesHashcode(self):
+        """Test that a change in the tx-mode will change the hashcode"""
+        gafDatasource = TestUtils.createGafDatasource(self.config)
+
+        gafDatasource.set_tx_mode(TranscriptProvider.TX_MODE_BEST_EFFECT)
+        old_hashcode = gafDatasource.get_hashcode()
+        gafDatasource.set_tx_mode(TranscriptProvider.TX_MODE_CANONICAL)
+        new_hashcode = gafDatasource.get_hashcode()
+        self.assertTrue(old_hashcode != new_hashcode)
+
     def _flattenChunks(self, chunks):
         [[(yield m) for m in c] for c in chunks]
 


### PR DESCRIPTION
This pull request makes sure that the md5 for the GAF datasource changes depending on what tx-mode it is using.  Note that the hashcode is generated dynamically, so the caller can simply change tx-mode and the hashcode will automatically update in every call to get_hashcode()
