### PR TITLE
altering appris selection to check for ccds tags

### DIFF
--- a/oncotator/datasources/EnsemblTranscriptDatasource.py
+++ b/oncotator/datasources/EnsemblTranscriptDatasource.py
@@ -297,6 +297,11 @@ class EnsemblTranscriptDatasource(TranscriptProvider, Datasource, SegmentDatasou
         tags =  set(tx.get_other_attributes().get('tag', "").split("|"))
         for tag in TranscriptProviderUtils.APPRIS_TAGS:
             if tag in tags:
+                if "CCDS" in tags:
+                    if tag == "appris_candidate":
+                        return appris_ranks["appris_candidate_ccds"]
+                    elif tag in {'appris_candidate_longest_seq', 'appris_candidate_longest'}:
+                        return appris_ranks["appris_candidate_longest_ccds"]
                 return appris_ranks[tag]
         else:
             return TranscriptProviderUtils.NO_APPRIS_VALUE

--- a/test/EnsemblTranscriptDatasourceTest.py
+++ b/test/EnsemblTranscriptDatasourceTest.py
@@ -191,6 +191,16 @@ class EnsemblTranscriptDatasourceTest(unittest.TestCase):
         self.assertEquals(ds._get_appris_rank(txs[0]), TranscriptProviderUtils.NO_APPRIS_VALUE)
 
     @TestUtils.requiresDefaultDB()
+    def test_appris_ccds_tag(self):
+        m = MutationData(chr="1", start="200818757", end="200818757", ref_allele="C", alt_allele="A", build="hg19")
+        transcript_ds = TestUtils.createTranscriptProviderDatasource(self.config)
+        m = transcript_ds.annotate_mutation(m)
+        tx = transcript_ds.get_transcript(m['annotation_transcript'])
+        self.assertTrue(tx is not None, "Transcript was None when it should have been found.  Does the ground truth transcript above need to be updated?")
+        self.assertEqual(tx._transcript_id,'ENST00000358823.2')
+
+
+    @TestUtils.requiresDefaultDB()
     def test_appris_selects_transcript(self):
         m = MutationData(chr="2", start="201722365", end="201722366", ref_allele="AC", alt_allele="-", build="hg19")
         transcript_ds = TestUtils.createTranscriptProviderDatasource(self.config)


### PR DESCRIPTION
updating appris selection because the tags listed on the gencode website are for gencode v21
in v19 the `CCDS` tag is separate from appris, and there is no `appris_candidate_ccds` or `appris_candidate_longest_ccds` tag.

See issue #231 for more info.
