### PR TITLE
Issue 326 oxo g fix collapsing

### DIFF
--- a/oncotator/MutationData.py
+++ b/oncotator/MutationData.py
@@ -240,3 +240,12 @@ class MutationData(collections.MutableMapping):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def createCopyAnnotation(self, annotation, new_name):
+        """Create a new annotation with exact same information as the old one.  In other words, all attributes will be the same.
+
+        :param annotation: instance of annotation
+        :param new_name: new name to attach to this instance.
+        """
+        self.createAnnotation(new_name, annotation.getValue(), annotation.getDatasource(),
+                                     annotation.getDataType(), annotation.getDescription(), tags=annotation.getTags(),
+                                     number=annotation.getNumber(), newRequired=self._new_required)

--- a/oncotator/Oncotator.py
+++ b/oncotator/Oncotator.py
@@ -58,7 +58,7 @@ Oncotator is a description
 
 It defines classes_and_methods
 
-@author:     aramos, mgupta, and lichtens
+@author:     aramos, lbergelson, mgupta, and lichtens
         
 @copyright:  2012 Broad Institute. All rights reserved.
         

--- a/oncotator/Oncotator.py
+++ b/oncotator/Oncotator.py
@@ -186,6 +186,7 @@ def parseOptions(program_version_message):
     parser.add_argument('--collapse-filter-cols', dest="collapse_filter_cols", action='store_true', help="Render FILTER columns from VCF input as single 'filter' column when using TCGAMAF ouput option.")
     parser.add_argument('--reannotate-tcga-maf-cols', action='store_true', help="Prefer new, annotated values to those specified by the input file.  Only useful when output is TCGA MAF and when --allow-overwriting is specified.  Automatically turned on with -i TCGAMAF")
     parser.add_argument('-w', '--allow-overwriting', action='store_true', help="Allow annotations to be overwritten (no DuplicateAnnotationException errors).  This should only be used in rare cases and user should know when that is.  Automatically turned on with -i TCGAMAF")
+    parser.add_argument('--collapse-number-annotations', action='store_true', help='Advanced:  For TCGA MAF output, collapse a set of known numeric fields that may have been annotated with a pipe.  This can be useful for downstream tools that are expecting a single value.')
 
     # Process arguments
     args = parser.parse_args()
@@ -322,6 +323,7 @@ def determineOtherOptions(args):
     opts[OptionConstants.COLLAPSE_FILTER_COLS] = args.collapse_filter_cols
     opts[OptionConstants.REANNOTATE_TCGA_MAF_COLS] = args.reannotate_tcga_maf_cols
     opts[OptionConstants.ALLOW_ANNOTATION_OVERWRITING] = args.allow_overwriting
+    opts[OptionConstants.COLLAPSE_NUMBER_ANNOTATIONS] = args.collapse_number_annotations
     return opts
 
 

--- a/oncotator/configs/column_collapse.config
+++ b/oncotator/configs/column_collapse.config
@@ -1,0 +1,27 @@
+# This file is a config file for ColumnCollapser instances.
+#
+#  key:value is <name of the annotation to collapse>:<method of collapse>
+#
+#  Currently, the method of collapse can only be: "min" or "mean" (without quotes).  If left blank, mean will be selected.
+#
+[columns_to_collapse]
+ALT_F2R1: min
+i_ALT_F2R1: min
+REF_F2R1: min
+i_REF_F2R1: min
+ALT_F1R2: min
+i_ALT_F1R2: min
+REF_F1R2: min
+i_REF_F1R2: min
+t_Foxog: mean
+i_t_Foxog: mean
+i_tumor_f: mean
+tumor_f: mean
+t_ref_count: min
+t_alt_count: min
+i_t_ref_count: min
+i_t_alt_count: min
+
+# These columns are for testing
+hamilcar: mean
+barca:

--- a/oncotator/configs/column_collapse.config
+++ b/oncotator/configs/column_collapse.config
@@ -25,7 +25,8 @@ n_ref_count: min
 n_alt_count: min
 i_n_ref_count: min
 i_n_alt_count: min
-
-# These columns are for testing
-hamilcar: mean
-barca:
+i_tumor_lod_fstar: mean
+tumor_lod_fstar: mean
+i_t_lod_fstar: mean
+t_lod_fstar: mean
+gc_content: mean

--- a/oncotator/configs/column_collapse.config
+++ b/oncotator/configs/column_collapse.config
@@ -21,6 +21,10 @@ t_ref_count: min
 t_alt_count: min
 i_t_ref_count: min
 i_t_alt_count: min
+n_ref_count: min
+n_alt_count: min
+i_n_ref_count: min
+i_n_alt_count: min
 
 # These columns are for testing
 hamilcar: mean

--- a/oncotator/output/TcgaMafOutputRenderer.py
+++ b/oncotator/output/TcgaMafOutputRenderer.py
@@ -219,6 +219,8 @@ class TcgaMafOutputRenderer(OutputRenderer):
         dw.writerow(row)
 
     def _add_output_annotations(self, m):
+        """Add annotations specific to the TCGA MAF
+        """
         m.createAnnotation('ncbi_build', self.lookupNCBI_Build(m.build), annotationSource="OUTPUT")
         if self._is_splitting_allelic_depth and m.get('allelic_depth', "").strip() != "":
             # Handle the splitting of allelic depth

--- a/oncotator/output/TcgaMafOutputRenderer.py
+++ b/oncotator/output/TcgaMafOutputRenderer.py
@@ -46,6 +46,7 @@ This Agreement is personal to LICENSEE and any rights or obligations assigned by
 7.6 Binding Effect; Headings. This Agreement shall be binding upon and inure to the benefit of the parties and their respective permitted successors and assigns. All headings are for convenience only and shall not affect the meaning of any provision of this Agreement.
 7.7 Governing Law. This Agreement shall be construed, governed, interpreted and applied in accordance with the internal laws of the Commonwealth of Massachusetts, U.S.A., without regard to conflict of laws principles.
 """
+from oncotator.utils.ColumnCollapser import ColumnCollapser
 from oncotator.utils.FieldMapCreator import FieldMapCreator
 from oncotator.utils.OptionConstants import OptionConstants
 
@@ -107,6 +108,13 @@ class TcgaMafOutputRenderer(OutputRenderer):
         self.exposedColumns = set(self.config.get("general", "exposedColumns").split(','))
 
         self._is_entrez_id_message_logged = False
+
+        self._is_collapsing_number_cols = options.get(OptionConstants.COLLAPSE_NUMBER_ANNOTATIONS, False)
+        self._column_collapser = None
+        self._column_collapser_suffix = None
+        if self._is_collapsing_number_cols:
+            self._column_collapser = ColumnCollapser()
+            self._column_collapser_suffix = "_full"
 
     def lookupNCBI_Build(self, build):
         """ If a build number exists in the config file, use that.  Otherwise, use the name specified. """
@@ -234,6 +242,8 @@ class TcgaMafOutputRenderer(OutputRenderer):
             m.createAnnotation(TcgaMafOutputRenderer.OUTPUT_T_ALT_COUNT, alt_count, "OUTPUT")
             m.createAnnotation(TcgaMafOutputRenderer.OUTPUT_T_REF_COUNT, ref_count, "OUTPUT")
 
+        if self._is_collapsing_number_cols:
+            self._column_collapser.update_mutation(m, "OUTPUT", self._column_collapser_suffix)
 
     def renderMutations(self, mutations, metadata=None, comments=None):
         """ Returns a file name pointing to the maf file that is generated. """
@@ -272,11 +282,17 @@ class TcgaMafOutputRenderer(OutputRenderer):
 
         if m is not None:
 
+            # Add columns for the new annotations created as part of collapsing cols
+            additional_internal_columns = []
+            if self._column_collapser is not None:
+                additional_internal_columns = self._column_collapser.retrieve_new_annotations_added(m, self._column_collapser_suffix)
+
             # Create a mapping between column name and annotation name
             field_map = FieldMapCreator.create_field_map(headers, m, self.alternativeDictionary,
                                                     self.config.getboolean("general", "displayAnnotations"),
                                                     exposed_fields=self.exposedColumns, prepend=self._prepend,
-                                                    deprioritize_input_annotations=self._is_reannotating)
+                                                    deprioritize_input_annotations=self._is_reannotating,
+                                                    additional_columns=additional_internal_columns)
 
             field_map_keys = field_map.keys()
             internal_fields = sorted(list(set(field_map_keys).difference(headers)))

--- a/oncotator/utils/ColumnCollapser.py
+++ b/oncotator/utils/ColumnCollapser.py
@@ -15,7 +15,7 @@ class ColumnCollapser(object):
 
     RENDER_AS_INT_IF_POSSIBLE = [MIN]
 
-    def __init__(self, config_file="configs/column_collapse.config"):
+    def __init__(self, config_file="column_collapse.config"):
         self._config_parser = ConfigUtils.createConfigParser(config_file, ignoreCase=False)
         self._columns_to_collapse = self._config_parser.options("columns_to_collapse")
 

--- a/oncotator/utils/ColumnCollapser.py
+++ b/oncotator/utils/ColumnCollapser.py
@@ -80,7 +80,7 @@ class ColumnCollapser(object):
         :return: dict with key value pairs of annotation_name:collapsed value.  This can then be used to update the mutation
         """
         result = dict()
-        relevant_annotations = list(set(mut.keys()).intersection(self._columns_to_collapse))
+        relevant_annotations = self._get_relevant_annotations(mut)
         for annot in relevant_annotations:
             result[annot] = self._collapse_column(annot, mut[annot])
         return result
@@ -102,3 +102,26 @@ class ColumnCollapser(object):
                 annotation.setDatasource(new_annotation_source)
             annotation.setValue(update_dict[u])
 
+    def _get_relevant_annotations(self, mut):
+        """
+
+        :param mut:
+        :return: list of annotations that will be collapsed given the mutation
+        """
+
+        return list(set(mut.keys()).intersection(self._columns_to_collapse))
+
+    def retrieve_new_annotations_added(self, mut, copy_old_suffix=None):
+        """
+        This method simply returns a list of annotations that would be created if run through update_mutation.
+
+        :param mut:annotated mutation with numeric fields to collapse (presumably)
+        :type mut MutationData
+        :param copy_old_suffix: suffix for the new annotations (that will hold the old values).  Please note that
+        this method will return an empty list if None (default) is specified
+        :return: list of str with annotation names.
+        """
+        if copy_old_suffix is None:
+            return []
+        relevant_annotations = self._get_relevant_annotations(mut)
+        return [a + copy_old_suffix for a in relevant_annotations]

--- a/oncotator/utils/ColumnCollapser.py
+++ b/oncotator/utils/ColumnCollapser.py
@@ -95,6 +95,7 @@ class ColumnCollapser(object):
         update_dict = self._collapse_columns(mut)
         for u in update_dict.keys():
             annotation = mut.getAnnotation(u)
-            annotation.setDatasource(new_annotation_source)
+            if new_annotation_source is not None:
+                annotation.setDatasource(new_annotation_source)
             annotation.setValue(update_dict[u])
 

--- a/oncotator/utils/ColumnCollapser.py
+++ b/oncotator/utils/ColumnCollapser.py
@@ -86,12 +86,13 @@ class ColumnCollapser(object):
         return result
 
     def update_mutation(self, mut, new_annotation_source=None, copy_old_suffix=None):
-        """ Given a mutation, update the relevant annotations with new values.  Please note that this
+        """ Given a mutation, update the relevant annotations with new values.  Please note that this updates in place.
+
         :param copy_old_suffix: Create another annotation with the old value in it.  Use this suffix  If None, do not create the annotation.
         :param new_annotation_source: string giving the annotation source that should be used for this updating of the mutation
             If set to None, leave the old annotation source in place (use sparingly).
         :param mut:
-        :return: mutation with updated annotation values
+        :return: None
         """
         update_dict = self._collapse_columns(mut)
         for u in update_dict.keys():

--- a/oncotator/utils/ColumnCollapser.py
+++ b/oncotator/utils/ColumnCollapser.py
@@ -1,0 +1,100 @@
+import logging
+from numpy.core.fromnumeric import mean
+from oncotator.utils.ConfigUtils import ConfigUtils
+
+class ColumnCollapser(object):
+    """This class takes multiple values in an annotation (separated by "|") and collapses into a single value based on given rules.
+
+        """
+
+    MIN = "min"
+    MEAN = "mean"
+
+    # Any methods specified above should be added to this list.
+    VALID_VALUES = [MIN, MEAN]
+
+    RENDER_AS_INT_IF_POSSIBLE = [MIN]
+
+    def __init__(self, config_file="configs/column_collapse.config"):
+        self._config_parser = ConfigUtils.createConfigParser(config_file, ignoreCase=False)
+        self._columns_to_collapse = self._config_parser.options("columns_to_collapse")
+
+        # Create a lookup table to get the method for each column
+        self._method_dict = dict()
+        if len(self._columns_to_collapse) != len(set(self._columns_to_collapse)):
+            logging.getLogger(__name__).warn("Duplicate keys in " + config_file + " seen.  Some collapsing may produce unexpected values.")
+
+        for c in self._columns_to_collapse:
+            self._method_dict[c] = self._config_parser.get("columns_to_collapse", c).strip()
+
+            # Default to mean if not specified
+            if self._method_dict[c] is None or self._method_dict[c] == "":
+                self._method_dict[c] = ColumnCollapser.MEAN
+
+        # Basic validation
+        problematic_method_assignments = dict()
+        for c in self._columns_to_collapse:
+            if self._method_dict[c] not in ColumnCollapser.VALID_VALUES:
+                problematic_method_assignments[c] = self._method_dict[c]
+
+        if len(problematic_method_assignments.keys()) > 0:
+            raise ValueError("Invalid column collapsing specified: " + str(problematic_method_assignments))
+
+
+    def _collapse_column(self, column_name, current_value):
+        """Here is where values are collapsed based on the input values.  Assumed t be separated by a "|"
+        current_value is assumed to be a string.
+        """
+        if column_name not in self._columns_to_collapse:
+            return current_value
+
+        list_vals = current_value.split("|")
+        no_blank_vals = [v for v in list_vals if v.strip() != "" and v.strip() != "."]
+
+        # if no "." is found in the value, assume that this should be rendered as an int, if MIN was chosen
+        #   we assume it is an int if no "." is found.
+        is_assuming_int = all([v.find(".") == -1 for v in no_blank_vals])
+
+        try:
+            if is_assuming_int:
+                final_vals = [int(v) for v in no_blank_vals]
+            else:
+                final_vals = [float(v) for v in no_blank_vals]
+        except ValueError as te:
+            logging.getLogger(__name__).warn("Could not collapse " + column_name + ":" + current_value + " into one number.  Returning the input value.")
+            return current_value
+
+        if len(final_vals) == 0:
+            return ""
+
+        if self._method_dict[column_name] == ColumnCollapser.MIN:
+            return str(min(final_vals))
+
+        elif self._method_dict[column_name] == ColumnCollapser.MEAN:
+            return str(mean(final_vals))
+
+    def _collapse_columns(self, mut):
+        """ Collapse the annotations in the mutation.
+
+        :param mut:
+        :return: dict with key value pairs of annotation_name:collapsed value.  This can then be used to update the mutation
+        """
+        result = dict()
+        relevant_annotations = list(set(mut.keys()).intersection(self._columns_to_collapse))
+        for annot in relevant_annotations:
+            result[annot] = self._collapse_column(annot, mut[annot])
+        return result
+
+    def update_mutation(self, mut, new_annotation_source=None):
+        """ Given a mutation, update the relevant annotations with new values.  Please note that this
+        :param new_annotation_source: string giving the annotation source that should be used for this updating of the mutation
+            If set to None, leave the old annotation source in place (use sparingly).
+        :param mut:
+        :return: mutation with updated annotation values
+        """
+        update_dict = self._collapse_columns(mut)
+        for u in update_dict.keys():
+            annotation = mut.getAnnotation(u)
+            annotation.setDatasource(new_annotation_source)
+            annotation.setValue(update_dict[u])
+

--- a/oncotator/utils/ColumnCollapser.py
+++ b/oncotator/utils/ColumnCollapser.py
@@ -85,8 +85,9 @@ class ColumnCollapser(object):
             result[annot] = self._collapse_column(annot, mut[annot])
         return result
 
-    def update_mutation(self, mut, new_annotation_source=None):
+    def update_mutation(self, mut, new_annotation_source=None, copy_old_suffix=None):
         """ Given a mutation, update the relevant annotations with new values.  Please note that this
+        :param copy_old_suffix: Create another annotation with the old value in it.  Use this suffix  If None, do not create the annotation.
         :param new_annotation_source: string giving the annotation source that should be used for this updating of the mutation
             If set to None, leave the old annotation source in place (use sparingly).
         :param mut:
@@ -95,6 +96,8 @@ class ColumnCollapser(object):
         update_dict = self._collapse_columns(mut)
         for u in update_dict.keys():
             annotation = mut.getAnnotation(u)
+            if copy_old_suffix is not None:
+                mut.createCopyAnnotation(annotation, u + copy_old_suffix)
             if new_annotation_source is not None:
                 annotation.setDatasource(new_annotation_source)
             annotation.setValue(update_dict[u])

--- a/oncotator/utils/OptionConstants.py
+++ b/oncotator/utils/OptionConstants.py
@@ -56,3 +56,4 @@ class OptionConstants(object):
     SPLIT_ALLELIC_DEPTH = 'split_allelic_depth'
     REANNOTATE_TCGA_MAF_COLS = 'reannotate_tcga_maf_cols'
     ALLOW_ANNOTATION_OVERWRITING = 'allow_annotation_overwriting'
+    COLLAPSE_NUMBER_ANNOTATIONS = 'collapse_number_fields'

--- a/oncotator/utils/RunSpecificationFactory.py
+++ b/oncotator/utils/RunSpecificationFactory.py
@@ -94,6 +94,9 @@ class RunSpecificationFactory(object):
         if other_opts.get(OptionConstants.ALLOW_ANNOTATION_OVERWRITING) and all([outputFormat != "TCGAMAF", outputFormat !="SIMPLE_TSV"]):
             result.append(RunSpecificationMessage(logging.WARN, "Asking to overwrite annotations for output format that is not TCGAMAF nor SIMPLE_TSV.  This is currently not supported.  Proceeding, but errors (or inconsistent annotations) are possible."))
 
+        if other_opts.get(OptionConstants.COLLAPSE_NUMBER_ANNOTATIONS) and all([outputFormat != "TCGAMAF"]):
+            result.append(RunSpecificationMessage(logging.WARN, "Asking to collapse numeric annotations for output format that is not TCGAMAF.  This is currently not supported and is ignored."))
+
         return result
 
     @staticmethod

--- a/test/ColumnCollapserTest.py
+++ b/test/ColumnCollapserTest.py
@@ -63,6 +63,22 @@ class ColumnCollapserTest(unittest.TestCase):
         self.assertEqual(m1['barca'], "carthage_rules")
         self.assertEqual(m1['donotcollapse'], "1|45")
 
+    def test_updating_annotation_source(self):
+        """Test that a String can be passed in to update the annotation source if columns are collapsed"""
+        m1 = MutationData()
+        m1.createAnnotation('ALT_F2R1', "|36", annotationSource="TEST")
+        cc = ColumnCollapser()
+        cc.update_mutation(m1, "foo")
+        self.assertEqual(m1.getAnnotation("ALT_F2R1").getDatasource(), "foo")
+
+    def test_not_updating_annotation_source(self):
+        """Test that do not have to update annotation source if columns are collapsed"""
+        m1 = MutationData()
+        m1.createAnnotation('ALT_F2R1', "|36", annotationSource="TEST")
+        cc = ColumnCollapser()
+        cc.update_mutation(m1)
+        self.assertEqual(m1.getAnnotation("ALT_F2R1").getDatasource(), "TEST")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/ColumnCollapserTest.py
+++ b/test/ColumnCollapserTest.py
@@ -65,6 +65,7 @@ class ColumnCollapserTest(unittest.TestCase):
 
     def test_updating_annotation_source(self):
         """Test that a String can be passed in to update the annotation source if columns are collapsed"""
+        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
         m1 = MutationData()
         m1.createAnnotation('ALT_F2R1', "|36", annotationSource="TEST")
         cc = ColumnCollapser()
@@ -73,11 +74,24 @@ class ColumnCollapserTest(unittest.TestCase):
 
     def test_not_updating_annotation_source(self):
         """Test that do not have to update annotation source if columns are collapsed"""
+        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
         m1 = MutationData()
         m1.createAnnotation('ALT_F2R1', "|36", annotationSource="TEST")
         cc = ColumnCollapser()
         cc.update_mutation(m1)
         self.assertEqual(m1.getAnnotation("ALT_F2R1").getDatasource(), "TEST")
+
+    def test_annotation_copy(self):
+        """Test that we can create a backup annotation with the old values after collapsing, if requested."""
+        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
+        m1 = MutationData()
+        m1.createAnnotation('ALT_F2R1', "|36", annotationSource="TEST")
+        cc = ColumnCollapser()
+        cc.update_mutation(m1, new_annotation_source="foo", copy_old_suffix="_full")
+        self.assertEqual(m1["ALT_F2R1_full"], "|36")
+        self.assertEqual(m1["ALT_F2R1"], "36")
+        self.assertEqual(m1.getAnnotation("ALT_F2R1_full").getDatasource(), "TEST")
+        self.assertTrue(m1.getAnnotation("ALT_F2R1").getDatasource() != m1.getAnnotation("ALT_F2R1_full").getDatasource())
 
 
 if __name__ == '__main__':

--- a/test/ColumnCollapserTest.py
+++ b/test/ColumnCollapserTest.py
@@ -1,0 +1,66 @@
+from oncotator.MutationData import MutationData
+from oncotator.utils.ColumnCollapser import ColumnCollapser
+from test.TestUtils import TestUtils
+
+__author__ = 'lichtens'
+
+import unittest
+
+TestUtils.setupLogging(__file__, __name__)
+class ColumnCollapserTest(unittest.TestCase):
+    def test_simple_collapse(self):
+        """Ensure simple rules for numeric collapsing are honored"""
+        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
+        m1 = MutationData()
+        m1.createAnnotation('ALT_F2R1', "34|36")
+        m1.createAnnotation('i_t_Foxog', ".509|.511")
+        m1.createAnnotation('i_tumor_f', ".200|.210")
+        m1.createAnnotation('hamilcar', "0|0")
+        m1.createAnnotation('donotcollapse', "1|45")
+
+        # m2 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
+        m2 = MutationData()
+        m2.createAnnotation('ALT_F2R1', "36|38")
+        m2.createAnnotation('i_t_Foxog', ".500|.510")
+        m2.createAnnotation('i_tumor_f', ".100|.110")
+        m2.createAnnotation('hamilcar', "0.01|0")
+        m2.createAnnotation('donotcollapse', "100|4500")
+
+        cc = ColumnCollapser()
+        cc.update_mutation(m1)
+        self.assertEqual(m1['ALT_F2R1'], "34")
+        self.assertEqual(float(m1['i_t_Foxog']), float(".510"))
+        self.assertEqual(float(m1['i_tumor_f']), float(".205"))
+        self.assertEqual(float(m1['hamilcar']), float("0"))
+        self.assertEqual(m1['donotcollapse'], "1|45")
+
+        cc.update_mutation(m2)
+        self.assertEqual(m2['ALT_F2R1'], "36")
+        self.assertEqual(float(m2['i_t_Foxog']), float(".505"))
+        self.assertEqual(float(m2['i_tumor_f']), float(".105"))
+        self.assertEqual(float(m2['hamilcar']), float("0.005"))
+        self.assertEqual(m2['donotcollapse'], "100|4500")
+
+    def test_cannot_collapse(self):
+        """Make sure that we move on when we cannot collapse values."""
+        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
+        m1 = MutationData()
+        m1.createAnnotation('ALT_F2R1', "|36")
+        m1.createAnnotation('i_t_Foxog', "|")
+        m1.createAnnotation('i_tumor_f', "")
+        m1.createAnnotation('hamilcar', "0|blah")
+        m1.createAnnotation('barca', "carthage_rules")
+        m1.createAnnotation('donotcollapse', "1|45")
+
+        cc = ColumnCollapser()
+        cc.update_mutation(m1)
+        self.assertEqual(m1['ALT_F2R1'], "36")
+        self.assertEqual(m1['i_t_Foxog'], "")
+        self.assertEqual(m1['i_tumor_f'], "")
+        self.assertEqual(m1['hamilcar'], "0|blah")
+        self.assertEqual(m1['barca'], "carthage_rules")
+        self.assertEqual(m1['donotcollapse'], "1|45")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/ColumnCollapserTest.py
+++ b/test/ColumnCollapserTest.py
@@ -1,4 +1,6 @@
+from oncotator.DuplicateAnnotationException import DuplicateAnnotationException
 from oncotator.MutationData import MutationData
+from oncotator.MutationDataFactory import MutationDataFactory
 from oncotator.utils.ColumnCollapser import ColumnCollapser
 from test.TestUtils import TestUtils
 
@@ -10,16 +12,14 @@ TestUtils.setupLogging(__file__, __name__)
 class ColumnCollapserTest(unittest.TestCase):
     def test_simple_collapse(self):
         """Ensure simple rules for numeric collapsing are honored"""
-        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
-        m1 = MutationData()
+        m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
         m1.createAnnotation('ALT_F2R1', "34|36")
         m1.createAnnotation('i_t_Foxog', ".509|.511")
         m1.createAnnotation('i_tumor_f', ".200|.210")
         m1.createAnnotation('hamilcar', "0|0")
         m1.createAnnotation('donotcollapse', "1|45")
 
-        # m2 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
-        m2 = MutationData()
+        m2 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
         m2.createAnnotation('ALT_F2R1', "36|38")
         m2.createAnnotation('i_t_Foxog', ".500|.510")
         m2.createAnnotation('i_tumor_f', ".100|.110")
@@ -45,8 +45,7 @@ class ColumnCollapserTest(unittest.TestCase):
 
     def test_cannot_collapse(self):
         """Make sure that we move on when we cannot collapse values."""
-        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
-        m1 = MutationData()
+        m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
         m1.createAnnotation('ALT_F2R1', "|36")
         m1.createAnnotation('i_t_Foxog', "|")
         m1.createAnnotation('i_tumor_f', "")
@@ -65,8 +64,7 @@ class ColumnCollapserTest(unittest.TestCase):
 
     def test_updating_annotation_source(self):
         """Test that a String can be passed in to update the annotation source if columns are collapsed"""
-        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
-        m1 = MutationData()
+        m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
         m1.createAnnotation('ALT_F2R1', "|36", annotationSource="TEST")
         cc = ColumnCollapser()
         cc.update_mutation(m1, "foo")
@@ -74,8 +72,7 @@ class ColumnCollapserTest(unittest.TestCase):
 
     def test_not_updating_annotation_source(self):
         """Test that do not have to update annotation source if columns are collapsed"""
-        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
-        m1 = MutationData()
+        m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
         m1.createAnnotation('ALT_F2R1', "|36", annotationSource="TEST")
         cc = ColumnCollapser()
         cc.update_mutation(m1)
@@ -83,8 +80,7 @@ class ColumnCollapserTest(unittest.TestCase):
 
     def test_annotation_copy(self):
         """Test that we can create a backup annotation with the old values after collapsing, if requested."""
-        # m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
-        m1 = MutationData()
+        m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
         m1.createAnnotation('ALT_F2R1', "|36", annotationSource="TEST")
         cc = ColumnCollapser()
         cc.update_mutation(m1, new_annotation_source="foo", copy_old_suffix="_full")
@@ -92,6 +88,28 @@ class ColumnCollapserTest(unittest.TestCase):
         self.assertEqual(m1["ALT_F2R1"], "36")
         self.assertEqual(m1.getAnnotation("ALT_F2R1_full").getDatasource(), "TEST")
         self.assertTrue(m1.getAnnotation("ALT_F2R1").getDatasource() != m1.getAnnotation("ALT_F2R1_full").getDatasource())
+
+    def test_annotation_copy_collision(self):
+        """Test that annotation copy will use the bahavior of the mutation in case of collision due to suffix"""
+        m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000")
+        m1.createAnnotation('ALT_F2R1', "30|36", annotationSource="TEST")
+        m1.createAnnotation('ALT_F2R1_full', "going_to_be_overwritten", annotationSource="TEST")
+
+        is_exception_seen = False
+        cc = ColumnCollapser()
+        try:
+            cc.update_mutation(m1, copy_old_suffix="_full")
+        except DuplicateAnnotationException as dae:
+            is_exception_seen = True
+        self.assertTrue(is_exception_seen, "Did not see duplicate annotation exception")
+
+        m1 = MutationDataFactory.default_create(chr="1", start="10000", end="10000", allow_overwriting=True)
+        m1.createAnnotation('ALT_F2R1', "30|36", annotationSource="TEST")
+        m1.createAnnotation('ALT_F2R1_full', "going_to_be_overwritten", annotationSource="TEST")
+        cc = ColumnCollapser()
+        cc.update_mutation(m1, copy_old_suffix="_full")
+        self.assertEqual(m1['ALT_F2R1_full'], "30|36")
+        self.assertEqual(m1['ALT_F2R1'], "30")
 
 
 if __name__ == '__main__':

--- a/test/ColumnCollapserTest.py
+++ b/test/ColumnCollapserTest.py
@@ -24,6 +24,7 @@ class ColumnCollapserTest(unittest.TestCase):
         m2.createAnnotation('i_t_Foxog', ".500|.510")
         m2.createAnnotation('i_tumor_f', ".100|.110")
         m2.createAnnotation('hamilcar', "0.01|0")
+        m2.createAnnotation('barca', "0.02|0")
         m2.createAnnotation('donotcollapse', "100|4500")
 
         cc = ColumnCollapser()
@@ -39,6 +40,7 @@ class ColumnCollapserTest(unittest.TestCase):
         self.assertEqual(float(m2['i_t_Foxog']), float(".505"))
         self.assertEqual(float(m2['i_tumor_f']), float(".105"))
         self.assertEqual(float(m2['hamilcar']), float("0.005"))
+        self.assertEqual(float(m2['barca']), float("0.01"))
         self.assertEqual(m2['donotcollapse'], "100|4500")
 
     def test_cannot_collapse(self):

--- a/test/MutationDataTest.py
+++ b/test/MutationDataTest.py
@@ -122,6 +122,13 @@ class MutationDataTest(unittest.TestCase):
         import cPickle
         cPickle.dump(m, open("out/testMDPickle.pkl", 'w'))
 
+    def test_copy(self):
+        """Test annotation copy """
+        m = MutationData()
+        m.createAnnotation("foo", "3", "blah_source", annotationDescription="testing", tags=["superblah"], number="A")
+        m.createCopyAnnotation(m.getAnnotation("foo"), "bar")
+        self.assertEqual(m.getAnnotation("foo"), m.getAnnotation("bar"))
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testSetValues']
     unittest.main()

--- a/test/MutationDataTest.py
+++ b/test/MutationDataTest.py
@@ -128,7 +128,10 @@ class MutationDataTest(unittest.TestCase):
         m = MutationData()
         m.createAnnotation("foo", "3", "blah_source", annotationDescription="testing", tags=["superblah"], number="A")
         m.createCopyAnnotation(m.getAnnotation("foo"), "bar")
+
+        # Note that getAnnotation returns an instance of Annotation, not simply the value
         self.assertEqual(m.getAnnotation("foo"), m.getAnnotation("bar"))
+
 
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testSetValues']

--- a/test/TcgaMafOutputRendererTest.py
+++ b/test/TcgaMafOutputRendererTest.py
@@ -566,7 +566,7 @@ class TcgaMafOutputRendererTest(unittest.TestCase):
         annotator.annotate()
 
         gt_alt_count = [80, 7]
-        gt_alt_count_full = ["80|82", "7"] # See issue #329.  If that is fixed, this test will need to switch 82 and 80
+        gt_alt_count_full = ["82|80", "7"]
         gt_ref_count = [68, 151]
 
         # Please note that this is not "68|68" since these were collapsed by ONP combiner.

--- a/test/TcgaMafOutputRendererTest.py
+++ b/test/TcgaMafOutputRendererTest.py
@@ -527,7 +527,7 @@ class TcgaMafOutputRendererTest(unittest.TestCase):
 
     @TestUtils.requiresDefaultDB()
     def test_reannotating_actual_file(self):
-        """Test that we can take in a file, annotate, similar to M2 process (VCF to TCGA MAF no ONPs, then TCGA MAF to TCGA MAF with ONPs)"""
+        """Test that we can take in a file, annotate, similar to M2 process (VCF to TCGA MAF no ONPs, then TCGA MAF to TCGA MAF with ONPs) and collapse values."""
         # This test assumes that the numeric values are not being collapsed.
         input_filename = "testdata/m2_support/phasingExample.vcf"
         midpoint_output_filename = "out/m2_support/reannotating_tcga_maf_midpoint.maf.annotated"
@@ -536,16 +536,21 @@ class TcgaMafOutputRendererTest(unittest.TestCase):
         options_step1 = {OptionConstants.COLLAPSE_FILTER_COLS: True, OptionConstants.NO_PREPEND: False,
                          OptionConstants.SPLIT_ALLELIC_DEPTH: True, OptionConstants.INFER_ONPS: False}
 
+        # Note that this will also test collapsing numeric values.
         options_step2 = {OptionConstants.REANNOTATE_TCGA_MAF_COLS: True, OptionConstants.INFER_ONPS: True,
-                   OptionConstants.ALLOW_ANNOTATION_OVERWRITING: True, OptionConstants.NO_PREPEND: False}
+                   OptionConstants.ALLOW_ANNOTATION_OVERWRITING: True, OptionConstants.NO_PREPEND: False,
+                   OptionConstants.COLLAPSE_NUMBER_ANNOTATIONS: True}
 
         run_spec_step1 = RunSpecificationFactory.create_run_spec("VCF", "TCGAMAF", input_filename, midpoint_output_filename,
-                                                                 cache_url="file://out/m2_support/tmp.cache", is_skip_no_alts=True,
-                                                                 other_opts=options_step1, datasource_dir=self._determine_db_dir())
+                                                                 is_skip_no_alts=True, other_opts=options_step1,
+                                                                 datasource_dir=self._determine_db_dir())
 
         annotator = Annotator()
         annotator.initialize(run_spec_step1)
         annotator.annotate()
+
+        # To speed up this test, use the same datasources from step 1
+        ds_list = run_spec_step1.get_datasources()
 
         tsv_reader = GenericTsvReader(midpoint_output_filename)
         i = -1
@@ -554,13 +559,21 @@ class TcgaMafOutputRendererTest(unittest.TestCase):
         self.assertTrue(i == 2, 'Mutation count flawed... should have been three mutations: ' + str(i+1))
 
 
-        run_spec_step2 = RunSpecificationFactory.create_run_spec("TCGAMAF", "TCGAMAF", midpoint_output_filename, output_filename,
-                                                                 cache_url="file://out/m2_support/tmp.cache",
-                                                                 other_opts=options_step2, datasource_dir=self._determine_db_dir(),
-                                                                 read_only_cache=True)
+        run_spec_step2 = RunSpecificationFactory.create_run_spec_given_datasources("TCGAMAF", "TCGAMAF", midpoint_output_filename, output_filename,
+                                                                 other_opts=options_step2, datasource_list=ds_list)
 
         annotator.initialize(run_spec_step2)
         annotator.annotate()
+
+        gt_alt_count = [80, 7]
+        gt_alt_count_full = ["80|82", "7"] # See issue #329.  If that is fixed, this test will need to switch 82 and 80
+        gt_ref_count = [68, 151]
+
+        # Please note that this is not "68|68" since these were collapsed by ONP combiner.
+        gt_ref_count_full = ["68", "151"]
+
+        gt_tumor_f = [.5375, .046]
+        gt_tumor_f_full = ["0.537|0.538", "0.046"]
 
         tsv_reader = GenericTsvReader(output_filename)
         i = -1
@@ -569,6 +582,14 @@ class TcgaMafOutputRendererTest(unittest.TestCase):
             self.assertTrue(all(is_good_prefix), "i_i_ prefix found.")
             if i == 0:
                 self.assertTrue(line["i_QSS"].find("|") != -1, "i_QSS tag should have a '|' in it for the first mutation")
+            self.assertEqual(int(line['t_alt_count']), gt_alt_count[i])
+            self.assertEqual(int(line['t_ref_count']), gt_ref_count[i])
+            self.assertEqual(float(line['i_tumor_f']), gt_tumor_f[i])
+
+            self.assertEqual(line['i_t_alt_count_full'], gt_alt_count_full[i])
+            self.assertEqual(line['i_t_ref_count_full'], gt_ref_count_full[i])
+            self.assertEqual(line['i_tumor_f_full'], gt_tumor_f_full[i])
+
         self.assertTrue(i == 1, 'Mutation count flawed... should have been two mutations: ' + str(i+1))
 
 

--- a/test/TcgaMafOutputRendererTest.py
+++ b/test/TcgaMafOutputRendererTest.py
@@ -573,7 +573,7 @@ class TcgaMafOutputRendererTest(unittest.TestCase):
         gt_ref_count_full = ["68", "151"]
 
         gt_tumor_f = [.5375, .046]
-        gt_tumor_f_full = ["0.537|0.538", "0.046"]
+        gt_tumor_f_full = ["0.538|0.537", "0.046"]
 
         tsv_reader = GenericTsvReader(output_filename)
         i = -1

--- a/test/configs/column_collapse.config
+++ b/test/configs/column_collapse.config
@@ -21,6 +21,15 @@ t_ref_count: min
 t_alt_count: min
 i_t_ref_count: min
 i_t_alt_count: min
+n_ref_count: min
+n_alt_count: min
+i_n_ref_count: min
+i_n_alt_count: min
+i_tumor_lod_fstar: mean
+tumor_lod_fstar: mean
+i_t_lod_fstar: mean
+t_lod_fstar: mean
+gc_content: mean
 
 # These columns are for testing
 hamilcar: mean

--- a/test/configs/column_collapse.config
+++ b/test/configs/column_collapse.config
@@ -1,0 +1,27 @@
+# This file is a config file for ColumnCollapser instances.
+#
+#  key:value is <name of the annotation to collapse>:<method of collapse>
+#
+#  Currently, the method of collapse can only be: "min" or "mean" (without quotes).  If left blank, mean will be selected.
+#
+[columns_to_collapse]
+ALT_F2R1: min
+i_ALT_F2R1: min
+REF_F2R1: min
+i_REF_F2R1: min
+ALT_F1R2: min
+i_ALT_F1R2: min
+REF_F1R2: min
+i_REF_F1R2: min
+t_Foxog: mean
+i_t_Foxog: mean
+i_tumor_f: mean
+tumor_f: mean
+t_ref_count: min
+t_alt_count: min
+i_t_ref_count: min
+i_t_alt_count: min
+
+# These columns are for testing
+hamilcar: mean
+barca:


### PR DESCRIPTION
- ``--collapse-number-annotations`` added to CLI  This tells Oncotator to take a known set of numeric columns (listed below) and convert into a single value based on a rule (currently only ``min`` and ``mean`` are supported).  This will eliminate the possibility of a ``|`` appearing in the column as the values will be collapsed according to the rule.

The current columns and rules are found in ``column_collapse.config`` in the source code.  These are key:value of ``annotation_name:method_applied``

Notes:
- There is no easy way for users to modify the list and rules found in ``column_collapse.config``
- Collapsing does not fail if blank or string values are found.  See examples below for behavior.
- "|" is the only delimiter recognized.
- The collapsing rules are driven off of annotation names, not column names in a TCGA MAF.  ``i_`` fields are included only to catch cases where these were specified in the input file.

Collapsing rules as of this writing:
```
# This file is a config file for ColumnCollapser instances.
#
#  key:value is <name of the annotation to collapse>:<method of collapse>
#
#  Currently, the method of collapse can only be: "min" or "mean" (without quotes).  If left blank, mean will be selected.
#
[columns_to_collapse]
ALT_F2R1: min
i_ALT_F2R1: min
REF_F2R1: min
i_REF_F2R1: min
ALT_F1R2: min
i_ALT_F1R2: min
REF_F1R2: min
i_REF_F1R2: min
t_Foxog: mean
i_t_Foxog: mean
i_tumor_f: mean
tumor_f: mean
t_ref_count: min
t_alt_count: min
i_t_ref_count: min
i_t_alt_count: min
n_ref_count: min
n_alt_count: min
i_n_ref_count: min
i_n_alt_count: min
i_tumor_lod_fstar: mean
tumor_lod_fstar: mean
i_t_lod_fstar: mean
t_lod_fstar: mean
gc_content: mean
```

Examples (incl. bad inputs):
mean:
```
0.1|0.2 --> 0.15
4|10 --> 7
4 --> 4
```
min:
```
0.1|0.2 --> 0.1
4|10 --> 4
10 --> 10
```

other examples:
```
# For columns not in the config file
4|6 --> 4|6

# Other examples (regardless of method)
| --> <blank>
|36 --> 36
<blank> --> <blank>
0|blah --> 0|blah
```

- A suffix is specified (``_full``) , which is used to create copies of the original, unaltered annotation.  Note that if the mutation in question does not allow overwriting, a DuplicateAnnotationException will be thrown.

Simple example:
```
# Input
annotation name: t_ref_count
value: 4|10

# Outputs to be rendered in the TCGA MAF 
annotation name: t_ref_count
value: 4

annotation name: t_ref_count_full
value: 4|10
```