### PR TITLE
Improving ONPCombiner's attribute merging

### DIFF
--- a/oncotator/input/OnpQueue.py
+++ b/oncotator/input/OnpQueue.py
@@ -163,8 +163,12 @@ class OnpQueue(object):
                 except KeyError:
                     pass
 
-            values = sorted((set([x.getValue() for x in annotations if x.getValue()])))
-            value = "|".join(values)
+            values = [x.getValue() for x in annotations ]
+            if len(set(values)) == 1:
+                value = values[0]   #if all annotations are identical then don't pipe separate them
+            else:
+                value = "|".join(values)
+
             tags = sorted(set(flatmap(lambda x: x.getTags(), annotations)))
             source = annotations[0].getDatasource()
             datatype = annotations[0].getDataType()


### PR DESCRIPTION
Fixes #329
Attributes that all have the same value for a combined mutation will be output only once.
If any values differ they will all be output int the order that the mutations were originally in.